### PR TITLE
Modifies build to deploy compile folder to Github

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ pipeline
     agent none
     stages 
     { 
-       stage ('Build') 
-       { 
+        stage ('Build') 
+        { 
             parallel 
             {
             
@@ -23,9 +23,13 @@ pipeline
 
                         runMATLABCommand 'buildScript'
                         runMATLABCommand 'testRatScript'
+                        sh 'mkdir build_linux'
+                        sh 'cp -R compile/* build_linux/'
+                        sh 'zip -r build_linux.zip build_linux -x "**/-lang:c++.zip"'
+                        archiveArtifacts artifacts: 'build_linux.zip', onlyIfSuccessful: true
                     }
                 }
-             
+                
                 stage('Build and Tests (Windows)') 
                 {
                     agent 
@@ -40,13 +44,39 @@ pipeline
                     {
                         runMATLABCommand 'buildScript'
                         runMATLABCommand 'testRatScript'
+                        bat 'mkdir build_windows'
+                        bat "xcopy /E /I compile build_windows"
+                        bat 'tar --exclude="**/-lang:c++.zip" -acvf build_windows.zip build_windows'
+                        archiveArtifacts artifacts: 'build_windows.zip', onlyIfSuccessful: true
                     }   
-
                 }
             } // parallel
-
-       }
-        
+        }//build
+        stage('Upload Linux Build') 
+        {       
+            agent { label 'RAT_Linux' }
+            options { skipDefaultCheckout() }
+            when { expression {env.BRANCH_NAME == 'master'} }
+            steps 
+            {
+                withCredentials([usernamePassword(credentialsId: '2b162eff-3b08-4d6b-b004-799ea4c82929', 
+                                                  usernameVariable: "GIT_USERNAME", passwordVariable: 'GIT_TOKEN')]) { 
+                    sh 'python3 release.py ${GIT_TOKEN} build_linux.zip'
+                }          
+            }
+        }//Upload linux build to GitHub from master
+        stage('Upload Windows Build') 
+        {          
+            agent { label 'RAT_Windows' }
+            options { skipDefaultCheckout() }  
+            when { expression {env.BRANCH_NAME == 'master'} }
+            steps 
+            {  
+                withCredentials([usernamePassword(credentialsId: '2b162eff-3b08-4d6b-b004-799ea4c82929', 
+                                                  usernameVariable: "GIT_USERNAME", passwordVariable: 'GIT_TOKEN')]) { 
+                                bat 'python release.py %GIT_TOKEN% build_windows.zip'
+                }
+            } 
+        }//Upload windows build to GitHub from master
     } // stages
-
 } //pipeline

--- a/release.py
+++ b/release.py
@@ -1,0 +1,70 @@
+"""This uploads a build artifact with the given filename as an assets in the GitHub 
+nightly release. If the asset already exists on GitHub, the existing one will be 
+deleted and replaced with the new build 
+
+USAGE: 
+
+    python release.py GITHUB_TOKEN FILENAME
+"""
+import argparse
+import json
+import urllib.request
+
+TOKEN = ''
+HEADERS = {}
+RELEASE_ID = 91574157  # ID of the nightly release
+
+def deleteAsset(assetID):
+    """Deletes a given asset from a GitHub release
+
+    :param assetID: ID of the asset to remove
+    :type assetID: int
+    """
+    url = f'https://api.github.com/repos/RascalSoftware/RAT/releases/assets/{assetID}'
+    request = urllib.request.Request(url, headers=HEADERS, method='DELETE')
+    urllib.request.urlopen(request)
+
+
+def uploadAsset(filename):
+    """Uploads a file as a GitHub release asset
+
+    :param filename: name of file to upload
+    :type filename: string
+    """
+    with open(filename, 'rb') as fp:
+        data = fp.read()
+
+    url = f'https://uploads.github.com/repos/RascalSoftware/RAT/releases/{RELEASE_ID}/assets?name={filename}"'
+    headers = {**HEADERS, 'Content-Type': 'application/octet-stream'}
+    request = urllib.request.Request(url, headers=headers, method='POST', data=data)
+    urllib.request.urlopen(request)
+    
+
+def getAssets():
+    """Gets all the assets for a specific release
+    
+    :return: asset name and id pair
+    :rtype: filename: Dict[string, int]
+    """
+    url = f'https://api.github.com/repos/RascalSoftware/RAT/releases/{RELEASE_ID}/assets'
+    request = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(request) as response:
+        assets = json.loads(response.read())
+        return {asset.get('name'): asset.get('id') for asset in assets}
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Helper to upload build to GitHub.')
+    parser.add_argument('token', help='Github token')
+    parser.add_argument('filename', help='name of file to upload')
+
+    args = parser.parse_args()
+    TOKEN = args.token
+    HEADERS = {'Accept': 'application/vnd.github+json', 'Authorization': f'Bearer {TOKEN}', 
+               'X-GitHub-Api-Version': '2022-11-28'}
+
+    assets = getAssets()
+    if args.filename in assets:
+        deleteAsset(assets[args.filename])
+    uploadAsset(args.filename)
+    print(f'{args.filename} uploaded successfully!')


### PR DESCRIPTION
The Jenkins file is modified to save the build on anvil and deploy as a nightly release when the branch is master (https://github.com/RascalSoftware/RAT/releases/tag/nightly). 

The GitHub release API is used to deploy the build via a Python script "release.py"

Closes #53 