### PR TITLE
Fixed scaling problem with Bayesian priors.

### DIFF
--- a/minimisers/DREAM/DREAMWrapper.m
+++ b/minimisers/DREAM/DREAMWrapper.m
@@ -19,7 +19,7 @@ problem = unpackparams(problem,control);
 % Function value is chi-squared....
 chiSquared = outProblem.calculations.sum_chi;
 
-Lik = exp(-chiSquared/2);
+Lik = -chiSquared/2;
 
 end
 

--- a/minimisers/DREAM/functions/calcDensity.m
+++ b/minimisers/DREAM/functions/calcDensity.m
@@ -45,14 +45,14 @@ if strcmp(DREAMPar.ABC,'no')
         % RAT specific prior funtion (mvnpdf)
         PR = zeros(1,DREAMPar.N);
         for i = 1:DREAMPar.N                                  % Loop over all the chains..
-            PR(i) = gaussLogPrior(x(i,:),ratInputs);          % mvnpdf automatically goes over all pars
+            PR(i) = scaledGaussPrior(x(i,:),ratInputs);          % mvnpdf automatically goes over all pars
         end
         
         % Take log of any non-zero values..
         log_PR = zeros(DREAMPar.N,1);
         for i = 1:length(PR)
             if PR(i) ~= 0
-                log_PR(i) = log(PR(i));     % Does it even need to be log?
+                log_PR(i) = PR(i);%log(PR(i));     % Does it even need to be log?
             else
                 % Otherwise keep the zero values
                 log_PR(i) = 0;
@@ -100,7 +100,7 @@ end
 
 % Loop over each model realization and calculate log-likelihood of each fx
 for ii = 1 : DREAMPar.N
-    log_L(ii,1) = log ( fx(1,ii) );
+    log_L(ii,1) =  fx(1,ii) ;
 end
 
 % ------------------ End Calculate log-likelihood -------------------------

--- a/minimisers/DREAM/scaledGaussPrior.m
+++ b/minimisers/DREAM/scaledGaussPrior.m
@@ -1,0 +1,55 @@
+function pVal2 = scaledGaussPrior(m,extras)
+
+
+problem = extras.problemDef;
+% problemDef_cells = extras{2};
+% problemDef_limits = extras{3};
+% controls = extras{4};
+priorList = extras.priors;
+
+% All are in range, so check for Gaussian priors....
+% We pick out any priors that are Gaussians and calculate the mvnpdf
+usedPriorInd = find(strcmpi(priorList(:,1),'gaussian'));
+
+% if ~isempty(gaussPriors)    % There may be no Gaussian priors defined!
+%     mus = [priorList{gaussPriors,2}];
+%     sigs = [priorList{gaussPriors,3}];
+%     pdf = mvnorpf(m(gaussPriors),mus,sigs);
+%     %pdf = mvnpdf(m(gaussPriors),mus,sigs);
+%     logPrior = pdf;%log(pdf);
+% else
+%     logPrior = 0;
+% end
+
+priorfun = @(th,mu,sig) sum(((th-mu)./sig).^2);
+fitConstr = problem.fitconstr;
+
+usedPriors = priorList(usedPriorInd,:);
+usedConstr = fitConstr(usedPriorInd,:);
+usedVals = m(usedPriorInd)';
+
+
+if ~isempty(usedPriorInd)    % There may be no Gaussian priors defined!
+    %     mus = [priorList{usedPriorInd,2}];
+    %     sigs = [priorList{usedPriorInd,3}];
+    %     x = m(usedPriorInd);
+    %     for i = 1:length(x)
+    %         p(i) = normpdf(x(i),mus(i),sigs(i));
+    %     end
+    %     prior = sum(p);
+
+    mu = [usedPriors{:,2}]';
+    sig = [usedPriors{:,3}]';
+    sigAdd = sig + usedConstr(:,1); % Scale (minVal+prior) will give scaled sigma since minVal goes to 0...
+
+    muSc = rescale(mu,'InputMin',usedConstr(:,1),'InputMax',usedConstr(:,2));
+    sigSc = rescale(sigAdd,'InputMin',usedConstr(:,1),'InputMax',usedConstr(:,2));
+    valsSc = rescale(usedVals,'InputMin',usedConstr(:,1),'InputMax',usedConstr(:,2));
+
+    pVal2 = priorfun(valsSc,muSc,sigSc);
+
+    pVal2 = -pVal2;
+
+else
+    pVal2 = 0;
+end

--- a/utilities/plotting/histp.m
+++ b/utilities/plotting/histp.m
@@ -38,7 +38,7 @@ if nargin<2|isempty(nbin)
   nbin=ceil(range(y)/(2*iqrange(y)*n^(-1/3))); % Freedman & Diaconis
 
   % bar(...,'w') does not work with nbin>150
-  nbin=min(150,nbin);
+  nbin=min(50,nbin);
 end
 
 % scaled histogram

--- a/utilities/plotting/plotBayesCorrFig.m
+++ b/utilities/plotting/plotBayesCorrFig.m
@@ -6,7 +6,7 @@ y = chain;
 nPars = size(chain,2);
 for i = 1:nPars
     
-    [N,edges] = histcounts(chain(:,i),50, 'Normalization','pdf');
+    [N,edges] = histcounts(chain(:,i),25, 'Normalization','pdf');
     edges2 = edges(2:end) - (edges(2)-edges(1))/2;
     N2 = smoothdata(N, 'movmean');
     newDists{i} = [N2(:) edges2(:)];
@@ -324,10 +324,10 @@ end
 % ---------------------------------------------------------------------
 function plotContours(x,y,ax)
 
-nbins = [100 100];
+nbins = [50 50];
 
 [N,C] = hist3([x(:) y(:)],nbins);
-K=(1/25)*ones(5);
+K=(1/10)*ones(5);
 N=conv2(N,K,'same');
 
 NN = N/sum(N(:));


### PR DESCRIPTION
Priors (parameters) can be either of the range 1-100 or ~ -1e-6 to 10e-6. Priors or the smaller values were not being picked up, since the sum over priors was being dominated by the larger values.

The solution is to scale all priors and parameters to the range between 0 to 1 using the built in 'rescale.m' function (in gaussLogPrior.m)

Also, moved from using log(likelihood) to just likelihood. This is because likelihood is exp(-chi^2/2), so log-likelihood is log(exp(x)). Exp(x) can be very small (approaching eps), so log(exp...) is numerically unwise.

Similarly, we use sum(priors) rather than log(sum(priors)).

Also tidied up bayes plotting functions.
