### PR TITLE
Refactors event manager to use enum class and std::function

### DIFF
--- a/compile/events/eventManager.cpp
+++ b/compile/events/eventManager.cpp
@@ -36,12 +36,12 @@ LIB_EXPORT void notify(const baseEvent& event)
 	eventManager::get_instance()->notify(event);
 }
 
-LIB_EXPORT void addListener(enum eventTypes type, const callback fn)
+LIB_EXPORT void addListener(EventTypes type, const std::function<void(const baseEvent&)> fn)
 {
-    if (type == MESSAGE)
-	    eventManager::get_instance()->addListener(MESSAGE, fn);
-    else if (type == PLOT)
-        eventManager::get_instance()->addListener(PLOT, fn);
+    if (type == EventTypes::Message)
+	    eventManager::get_instance()->addListener(EventTypes::Message, fn);
+    else if (type == EventTypes::Plot)
+        eventManager::get_instance()->addListener(EventTypes::Plot, fn);
 }
 
 LIB_EXPORT void clearListeners()
@@ -53,7 +53,7 @@ LIB_EXPORT bool hasPlotHandler()
 {   
     auto names = eventManager::get_instance()->getEventNames();
 	for(unsigned i=0; i < names.size(); i++) {
-        if (names[i] == PLOT)
+        if (names[i] == EventTypes::Plot)
             return true;
     }
     return false;

--- a/compile/events/eventManager.h
+++ b/compile/events/eventManager.h
@@ -22,7 +22,7 @@ LIB_EXPORT void sendMessage(const char* msg);
 
 LIB_EXPORT void notify(const baseEvent& event);
 
-LIB_EXPORT void addListener(enum eventTypes type, const callback fn);
+LIB_EXPORT void addListener(EventTypes type, const std::function<void(const baseEvent&)> fn);
 
 LIB_EXPORT void clearListeners();
 

--- a/compile/events/eventManagerImpl.hpp
+++ b/compile/events/eventManagerImpl.hpp
@@ -3,14 +3,15 @@
 
 #include <mutex>
 #include <vector>
+#include <functional>
 
 /* 
   Implementation of a singleton event manager with support for multiple 
   event types.
 */
-enum eventTypes {
-  MESSAGE,
-  PLOT
+enum class EventTypes {
+  Message,
+  Plot
 }; 
 
 
@@ -36,23 +37,20 @@ struct plotData {
 
 
 struct baseEvent {
-    enum eventTypes type;
-    baseEvent(enum eventTypes type) : type(type) {}
+    EventTypes type;
+    baseEvent(EventTypes type) : type(type) {}
     virtual ~baseEvent() {}
 };
 
 struct messageEvent : baseEvent {
     const char* msg;
-    messageEvent(const char* msg) : baseEvent(MESSAGE), msg(msg) {}
+    messageEvent(const char* msg) : baseEvent(EventTypes::Message), msg(msg) {}
 };
 
 struct plotEvent : baseEvent {
     const plotData* data;
-    plotEvent(const plotData* data) : baseEvent(PLOT),  data(data) {}
+    plotEvent(const plotData* data) : baseEvent(EventTypes::Plot),  data(data) {}
 };
-
-
-typedef void (*callback) (const baseEvent&);
 		     
 		     	      
 class eventManager
@@ -63,9 +61,9 @@ public:
     eventManager& operator=(eventManager const&) = delete;
     ~eventManager() {}
     
-    const std::vector<enum eventTypes>& getEventNames()const {return eventNames;}
+    const std::vector<EventTypes>& getEventNames()const {return eventNames;}
 
-    void addListener(enum eventTypes type, const callback fn) {
+    void addListener(EventTypes type, const std::function<void(const baseEvent&)> fn) {
        std::lock_guard<std::mutex> lock(m_mutex);
 	   eventNames.push_back(type);
        eventHandlers.push_back(fn);
@@ -93,8 +91,8 @@ public:
 
 private:
     explicit eventManager() {}
-    std::vector<enum eventTypes> eventNames;
-    std::vector<void (*)(const baseEvent&)> eventHandlers;
+    std::vector<EventTypes> eventNames;
+    std::vector<std::function<void(const baseEvent&)>> eventHandlers;
     std::mutex m_mutex;
 };
 

--- a/targetFunctions/reflectivityCalculation.m
+++ b/targetFunctions/reflectivityCalculation.m
@@ -16,8 +16,6 @@ function [contrastParams,resultCells] = reflectivityCalculation(problemStruct,pr
 % * magnetic       - Target function for cases for polarised neutrons with polarisation analysis.
 %                       
 
-% triggerEvent('message', 'Running reflectivity calculation...');
-
 % for compilation, we have to preallocate memory for the output arrays
 % Setting these parameters in the struct defines them as doubles
 contrastParams.ssubs = 0;


### PR DESCRIPTION
Refactors event manager to use c++ enum class and std::function callback instead of the c-style version used before. This would make it easier for the pybind extension implementation