### PR TITLE
Adds action to deploy generated C++ code to a separate branch

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -55,11 +55,11 @@ jobs:
       with:
         ref: generated_source
         path: rat_source
-    - name: Deploy Souce
+    - name: Deploy Source
       run: |
         wget https://github.com/RascalSoftware/RAT/releases/download/nightly/Linux.zip
         unzip Linux.zip
-        rm -rf rat_source/*.c rat_source/*.cpp rat_source/*.h
+        rm -rf rat_source/*.c rat_source/*.cpp rat_source/*.h rat_source/*.hpp
         rsync -av compile/fullCompile/cppDeploy/ rat_source/
         cd rat_source
         git config user.name github-actions

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -19,21 +19,21 @@ jobs:
  
     steps:
     - name: Checkout RAT
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build Mex
-      uses: matlab-actions/run-command@v1
+      uses: matlab-actions/run-command@v2
       with:
-        command: buildScript  
+        command: buildScript, cppDeploy  
     - name: Run tests
-      uses: matlab-actions/run-command@v1
+      uses: matlab-actions/run-command@v2
       with:
         command: testScript
     - name: Create build archive (Windows and macOS)
       if: runner.os != 'Linux'
-      run:  tar --exclude="**/-lang:c++.zip" -acvf ${{ runner.os }}.zip compile
+      run:  tar --exclude="**/-lang:c++.zip" --exclude=".git*/" --exclude="htmlcov/" -acvf ../${{ runner.os }}.zip *
     - name: Create build archive (Linux)
       if: runner.os == 'Linux'
-      run:  zip -r ${{ runner.os }}.zip compile -x "**/-lang:c++.zip" 
+      run:  zip -r ../${{ runner.os }}.zip * -x "**/-lang:c++.zip" ".git*/" "htmlcov/"
     - name: Upload release
       if: github.ref == 'refs/heads/master'
       uses: svenstaro/upload-release-action@v2
@@ -42,5 +42,28 @@ jobs:
       with:
         tag: nightly
         overwrite: true
-        file: '${{ runner.os }}.zip'
+        file: '../${{ runner.os }}.zip'
         asset_name: '${{ runner.os }}.zip'
+  
+  cpp-deploy:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v4
+      with:
+        ref: generated_source
+        path: rat_source
+    - name: Deploy Souce
+      run: |
+        wget https://github.com/RascalSoftware/RAT/releases/download/nightly/Linux.zip
+        unzip Linux.zip
+        rm -rf rat_source/*.c rat_source/*.cpp rat_source/*.h
+        rsync -av compile/fullCompile/cppDeploy/ rat_source/
+        cd rat_source
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add -A
+        git commit -m "Deploy Source Code" || true
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ devProjects/
 -lang*
 paramonte_out/
 codegen/
+cppDeploy/
 *.mexa64
 *.mexw64
 *.mexmaci64

--- a/cppDeploy.m
+++ b/cppDeploy.m
@@ -1,0 +1,14 @@
+% Copies all files required to build cpp to 'cppDeploy' folder
+[~, ~, ~] = rmdir('compile/fullCompile/cppDeploy', 's');
+load compile/fullCompile/codegen/lib/RATMain/buildInfo.mat;
+packNGo(buildInfo,'fileName','deploy.zip');
+unzip('compile/fullCompile/deploy.zip', 'compile/fullCompile/cppDeploy');
+
+% Copy events
+mkdir('compile/fullCompile/cppDeploy/events/');
+copyfile('compile/events/eventManager.cpp', 'compile/fullCompile/cppDeploy/events/eventManager.cpp');
+copyfile('compile/events/eventManager.h', 'compile/fullCompile/cppDeploy/events/eventManager.h');
+copyfile('compile/events/eventManagerImpl.hpp', 'compile/fullCompile/cppDeploy/events/eventManagerImpl.hpp');
+
+% Clean up
+delete 'compile/fullCompile/deploy.zip' 'compile/fullCompile/cppDeploy/buildInfo.mat';

--- a/cppDeploy.m
+++ b/cppDeploy.m
@@ -11,4 +11,4 @@ copyfile('compile/events/eventManager.h', 'compile/fullCompile/cppDeploy/events/
 copyfile('compile/events/eventManagerImpl.hpp', 'compile/fullCompile/cppDeploy/events/eventManagerImpl.hpp');
 
 % Clean up
-delete 'compile/fullCompile/deploy.zip' 'compile/fullCompile/cppDeploy/buildInfo.mat';
+delete 'compile/fullCompile/deploy.zip' 'compile/fullCompile/cppDeploy/buildInfo.mat' 'compile/fullCompile/cppDeploy/rtw_proj.tmw';


### PR DESCRIPTION
- The _cppDeploy_ script uses the  _packNGo_ function to get all files required to build the cpp and adds the event files also
- Theses files are deployed to the **generated_source** branch by the Github action
- The OS specific nightly releases i.e. Linux.zip, Windows.zip now include the whole source not just the **compile** folder
