### PR TITLE
Fixes bug where Linux nightly archive was not overwritten

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -33,7 +33,9 @@ jobs:
       run:  tar --exclude="**/-lang:c++.zip" --exclude=".git*/" --exclude="htmlcov/" -acvf ../${{ runner.os }}.zip *
     - name: Create build archive (Linux)
       if: runner.os == 'Linux'
-      run:  zip -r ../${{ runner.os }}.zip * -x "**/-lang:c++.zip" ".git*/" "htmlcov/"
+      run: |
+        rm -rf ../${{ runner.os }}.zip
+        zip -r ../${{ runner.os }}.zip * -x "**/-lang:c++.zip" ".git*/" "htmlcov/"
     - name: Upload release
       if: github.ref == 'refs/heads/master'
       uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Nightly for Linux is not updated properly because zip is merging instead of overwriting