### PR TITLE
Replaces the essential fprintf with message events

### DIFF
--- a/API/RATMain.m
+++ b/API/RATMain.m
@@ -16,22 +16,22 @@ switch controls.procedure
         result = reflectivityCalculation(problemStruct,problemCells,problemLimits,controls);
     case coderEnums.procedures.Simplex
         if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-            fprintf('\nRunning simplex\n\n');
+            triggerEvent(coderEnums.eventTypes.Message, sprintf('\nRunning simplex\n\n'));
         end
         [problemStruct,result] = runSimplex(problemStruct,problemCells,problemLimits,controls);
     case coderEnums.procedures.DE
         if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-            fprintf('\nRunning Differential Evolution\n\n');
+            triggerEvent(coderEnums.eventTypes.Message, sprintf('\nRunning Differential Evolution\n\n'));
         end
         [problemStruct,result] = runDE(problemStruct,problemCells,problemLimits,controls);
     case coderEnums.procedures.NS
         if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-            fprintf('\nRunning Nested Sampler\n\n');
+            triggerEvent(coderEnums.eventTypes.Message, sprintf('\nRunning Nested Sampler\n\n'));
         end            
         [problemStruct,result,bayesResults] = runNestedSampler(problemStruct,problemCells,problemLimits,controls,priors);   
     case coderEnums.procedures.Dream
         if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-            fprintf('\nRunning DREAM\n\n');
+            triggerEvent(coderEnums.eventTypes.Message, sprintf('\nRunning DREAM\n\n'));
         end
         [problemStruct,result,bayesResults] = runDREAM(problemStruct,problemCells,problemLimits,controls,priors);
     otherwise

--- a/minimisers/DE/deopt.m
+++ b/minimisers/DE/deopt.m
@@ -107,15 +107,15 @@ I_plotting   = S_struct.I_plotting;
 %-----Check input variables---------------------------------------------
 if (I_NP < 5)
    I_NP=5;
-   fprintf(1,' I_NP increased to minimal value 5\n');
+   triggerEvent(coderEnums.eventTypes.Message, sprintf('I_NP increased to minimal value 5\n'));
 end
 if ((F_CR < 0) | (F_CR > 1))
    F_CR=0.5;
-   fprintf(1,'F_CR should be from interval [0,1]; set to default value 0.5\n');
+   triggerEvent(coderEnums.eventTypes.Message, sprintf('F_CR should be from interval [0,1]; set to default value 0.5\n'));
 end
 if (I_itermax <= 0)
    I_itermax = 200;
-   fprintf(1,'I_itermax should be > 0; set to default value 200\n');
+   triggerEvent(coderEnums.eventTypes.Message, sprintf('I_itermax should be > 0; set to default value 200\n'));
 end
 I_refresh = floor(I_refresh);
 
@@ -305,7 +305,8 @@ while ((I_iter < I_itermax) && (S_bestval.FVr_oa(1) > F_VTR))
 
   if (I_refresh > 0)
      if ((rem(I_iter,I_refresh) == 0) || I_iter == 1) && strcmpi(controls.display, coderEnums.displayOptions.Iter)
-       fprintf('Iteration: %g,  Best: %f,  fWeight: %f,  F_CR: %f,  I_NP: %g\n\n', I_iter,S_bestval.FVr_oa(1),fWeight,F_CR,I_NP);
+      triggerEvent(coderEnums.eventTypes.Message, ...
+                   sprintf('Iteration: %g,  Best: %f,  fWeight: %f,  F_CR: %f,  I_NP: %g\n\n', I_iter,S_bestval.FVr_oa(1),fWeight,F_CR,I_NP));
 
        %disp(S_bestval);
        %var(FM_pop)
@@ -328,7 +329,7 @@ while ((I_iter < I_itermax) && (S_bestval.FVr_oa(1) > F_VTR))
     
      if isRATStopped(controls.IPCFilePath)
         if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-            fprintf('Optimisation terminated by user\n');
+            triggerEvent(coderEnums.eventTypes.Message, sprintf('Optimisation terminated by user\n'));
         end
         break;
      end

--- a/minimisers/DE/deopt.m
+++ b/minimisers/DE/deopt.m
@@ -305,8 +305,8 @@ while ((I_iter < I_itermax) && (S_bestval.FVr_oa(1) > F_VTR))
 
   if (I_refresh > 0)
      if ((rem(I_iter,I_refresh) == 0) || I_iter == 1) && strcmpi(controls.display, coderEnums.displayOptions.Iter)
-      triggerEvent(coderEnums.eventTypes.Message, ...
-                   sprintf('Iteration: %g,  Best: %f,  fWeight: %f,  F_CR: %f,  I_NP: %g\n\n', I_iter,S_bestval.FVr_oa(1),fWeight,F_CR,I_NP));
+        triggerEvent(coderEnums.eventTypes.Message, ...
+                     sprintf('Iteration: %g,  Best: %f,  fWeight: %f,  F_CR: %f,  I_NP: %g\n\n', I_iter,S_bestval.FVr_oa(1),fWeight,F_CR,I_NP));
 
        %disp(S_bestval);
        %var(FM_pop)

--- a/minimisers/DE/runDE.m
+++ b/minimisers/DE/runDE.m
@@ -104,7 +104,7 @@ function [problemStruct,result] = runDE(problemStruct,problemCells,problemLimits
     result = reflectivityCalculation(problemStruct,problemCells,problemLimits,controls);
     
     if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-        fprintf('Final chi squared is %g\n',result.calculationResults.sumChi);
+        triggerEvent(coderEnums.eventTypes.Message, sprintf('Final chi squared is %g\n',result.calculationResults.sumChi));
     end
 
 end

--- a/minimisers/DREAM/functions/ratDREAM.m
+++ b/minimisers/DREAM/functions/ratDREAM.m
@@ -161,9 +161,7 @@ end
 % Now print to screen all the settings
 controls = ratInputs.controls;
 if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-    fprintf('------------------ Summary of the main settings used ------------------\n');
-    disp(DREAMPar);
-    fprintf('-----------------------------------------------------------------------\n');
+    printParameters(DREAMPar);
 end
 % Now check how the measurement sigma is arranged (estimated or defined)
 %
@@ -276,7 +274,7 @@ for t = T_start : DREAMPar.nGenerations
     
     if isRATStopped(controls.IPCFilePath)
         if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-            fprintf('Optimisation terminated by user\n');
+            triggerEvent(coderEnums.eventTypes.Message, sprintf('Optimisation terminated by user\n'));
         end
         break;
     end
@@ -299,4 +297,31 @@ output.iloc = iloc;
 % Close the waitbar
 triggerEvent(coderEnums.eventTypes.Progress, 'DREAM', 1);
 %close(h);
+end
+
+
+function printParameters(DREAMPar)
+    % Print the dream parameters
+    coder.varsize('setting', [1 Inf], [0 1]);
+    setting = sprintf('------------------ Summary of the main settings used ------------------\n');
+    names = fieldnames(DREAMPar);
+    bools = {'false', 'true'};
+    for k=1:numel(names)
+        setting = strjoin({setting, sprintf('%25s: ', names{k})});
+        value = DREAMPar.(names{k});
+        if isnumeric(value)
+            if numel(value) ~= 1
+                dim = size(value);
+                setting = strjoin({setting, sprintf('[%gx%g %s]\n', dim(1), dim(2), class(value))});
+            else
+                setting = strjoin({setting, sprintf('%.8g\n', value(1))});
+            end
+        elseif islogical(value)
+            setting = strjoin({setting, sprintf('%s\n', bools{double(value) + 1})});
+        else
+            setting = strjoin({setting, sprintf('''%s''\n', value)});
+        end
+    end
+    setting = strjoin({setting, sprintf('-----------------------------------------------------------------------\n')});
+    triggerEvent(coderEnums.eventTypes.Message, setting);
 end

--- a/minimisers/DREAM/functions/removeOutlier.m
+++ b/minimisers/DREAM/functions/removeOutlier.m
@@ -203,7 +203,7 @@ if ( N < 61 ) && ( N > 2 )
 else
     if N >= 61
         N = 60; n_ind = size(peirce_r,1);
-        fprintf('DREAMPar.nChains > 60; using Peirce r-values for DREAMPar.nChains is 60');
+        triggerEvent(coderEnums.eventTypes.Message, 'DREAMPar.nChains > 60; using Peirce r-values for DREAMPar.nChains is 60');
     end
     if N < 2
         error('Insufficient number of chains to apply Peirce diagnostic');

--- a/minimisers/NS/drawMCMC.m
+++ b/minimisers/NS/drawMCMC.m
@@ -184,7 +184,7 @@ end
 
 % print out acceptance ratio
 if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-    fprintf('Acceptance ratio: %1.4f, \n\n', acctot/(Ntimes*nMCMC));
+    triggerEvent(coderEnums.eventTypes.Message, sprintf('Acceptance ratio: %1.4f, \n\n', acctot/(Ntimes*nMCMC)));
 end
 
 return

--- a/minimisers/NS/nestedSampler.m
+++ b/minimisers/NS/nestedSampler.m
@@ -271,12 +271,12 @@ while tol > tolerance || j <= nLive
     
     % display progress (optional)
     if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-        fprintf('log(Z): %.5e, tol = %.5e, K = %d, iteration = %d, H = %.5e\n', ...
-                 logZ, tol, int32(K), int32(j), H);
+        triggerEvent(coderEnums.eventTypes.Message, sprintf('log(Z): %.5e, tol = %.5e, K = %d, iteration = %d, H = %.5e\n', ...
+                 logZ, tol, int32(K), int32(j), H));
     end
     if isRATStopped(controls.IPCFilePath)
         if ~strcmpi(controls.display, coderEnums.displayOptions.Off)
-            fprintf('Optimisation terminated by user\n');
+            triggerEvent(coderEnums.eventTypes.Message, sprintf('Optimisation terminated by user\n'));
         end
         break;
     end

--- a/minimisers/simplex/fMinSearch.m
+++ b/minimisers/simplex/fMinSearch.m
@@ -237,8 +237,9 @@ how = '';
 
 % Print out initial f(x) as 0th iteration
 if prnt == 3
-    fprintf('\n%s\n', header);
-    fprintf(' %5.0f        %5.0f     %12.6g         %s\n', itercount, func_evals, fv(1), how);
+    triggerEvent(coderEnums.eventTypes.Message, sprintf('\n%s\n', header));
+    triggerEvent(coderEnums.eventTypes.Message, ...
+                 sprintf(' %5.0f        %5.0f     %12.6g         %s\n', itercount, func_evals, fv(1), how));
 % elseif prnt == 4
     % Option never used in RAT
     
@@ -299,7 +300,8 @@ how = 'initial simplex';
 itercount = itercount + 1;
 func_evals = n+1;
 if prnt == 3
-    fprintf(' %5.0f        %5.0f     %12.6g         %s\n', itercount, func_evals, fv(1), how);
+    triggerEvent(coderEnums.eventTypes.Message, ...
+                 sprintf(' %5.0f        %5.0f     %12.6g         %s\n', itercount, func_evals, fv(1), how));
 % elseif prnt == 4
 %     fprintf('%s \n', ' ')
 %     fprintf('%s \n', how)
@@ -418,7 +420,7 @@ while func_evals < maxfun && itercount < maxiter
     v = v(:,j);
     itercount = itercount + 1;
     if prnt == 3
-        fprintf(' %5.0f        %5.0f     %12.6g         %s\n', itercount, func_evals, fv(1), how);
+        triggerEvent(coderEnums.eventTypes.Message, sprintf(' %5.0f        %5.0f     %12.6g         %s\n', itercount, func_evals, fv(1), how));
 %     elseif prnt == 4
 %         fprintf('%s \n', ' ')
 %         fprintf('%s \n', num2str(how))
@@ -490,7 +492,7 @@ if buildOutputStruct
 end
 
 if printMsg
-    fprintf('\n%s\n', msg);
+    triggerEvent(coderEnums.eventTypes.Message, sprintf('\n%s\n', msg));
 end
 end
 %--------------------------------------------------------------------------
@@ -541,9 +543,9 @@ function [x, fval, exitflag, output] = cleanUpInterrupt(optX, optVal, iteration,
     output.iterations = iteration;
     output.funcCount = funccount;
     output.algorithm = 'Nelder-Mead simplex direct search';
-    output.message = sprintf('Optimisation terminated by user');
+    output.message = 'Optimisation terminated by user';
     if display > 0
-        fprintf('\n%s\n', output.message);
+        triggerEvent(coderEnums.eventTypes.Message, sprintf('\n%s\n', output.message));
     end
 end
 


### PR DESCRIPTION
Replaced fprintf with events to fix redirect issues.

I did not replace the following:

- `fprintf` in comments or commented code
- `fprintf` in dream diagnostic since these are not built
- `fprintf` which are hidden by the NS Debug variable