### PR TITLE
Fix DE crash

### DIFF
--- a/API/projectClass/parametersClass.m
+++ b/API/projectClass/parametersClass.m
@@ -108,7 +108,7 @@ classdef parametersClass < tableUtilities
                 
                 % Type validation
                 if ~isnumeric(values)
-                    throw(exceptions.invalidType('Expecting numeric values as params 2 - 4'));
+                    throw(exceptions.invalidType('Lower limit, value, and upper limit (2nd, 3rd and 4th arguments) must be numeric values'));
                 end
                 
                 if values(1) > values(3)
@@ -116,11 +116,11 @@ classdef parametersClass < tableUtilities
                 end
 
                 if values(2) < values(1) || values(2) > values(3)
-                    throw(exceptions.invalidValue(sprintf('Parameter value %f must be within the limits %f -- %f', values(2), values(1), values(3))));
+                    throw(exceptions.invalidValue(sprintf('Parameter value %f must be within the limits %f to %f', values(2), values(1), values(3))));
                 end
 
                 if ~islogical(fit)
-                    throw(exceptions.invalidType('Expecting logical value for param 5'));
+                    throw(exceptions.invalidType('Parameter fit (5th argument) must be a logical value'));
                 end
                 
                 priorType = validateOption(priorType, 'priorTypes', obj.invalidPriorsMessage).value;
@@ -204,7 +204,7 @@ classdef parametersClass < tableUtilities
             end
 
             if value < min || value > max
-                throw(exceptions.invalidValue(sprintf('Parameter value %f must be within the limits %f -- %f', value, min, max)));
+                throw(exceptions.invalidValue(sprintf('Parameter value %f must be within the limits %f to %f', value, min, max)));
             end
 
             % Apply values
@@ -280,7 +280,7 @@ classdef parametersClass < tableUtilities
             end
 
             if value < min || value > max
-                throw(exceptions.invalidValue(sprintf('Parameter value %f must be within the limits %f -- %f', value, min, max)));
+                throw(exceptions.invalidValue(sprintf('Parameter value %f must be within the limits %f to %f', value, min, max)));
             end
 
             tab(row,3) = {value};

--- a/minimisers/DE/deopt.m
+++ b/minimisers/DE/deopt.m
@@ -189,7 +189,7 @@ FM_meanv = ones(I_NP,I_D);
 
 if (S_bestval.FVr_oa(1) <= F_VTR)
    % In this case the while loop should never run so reset 
-   % the random generated best result to default
+   % the best result to the initial value
    FVr_bestmem = problem.params;
 end
 

--- a/minimisers/DE/deopt.m
+++ b/minimisers/DE/deopt.m
@@ -109,7 +109,7 @@ if (I_NP < 5)
    I_NP=5;
    triggerEvent(coderEnums.eventTypes.Message, sprintf('I_NP increased to minimal value 5\n'));
 end
-if ((F_CR < 0) | (F_CR > 1))
+if ((F_CR < 0) || (F_CR > 1))
    F_CR=0.5;
    triggerEvent(coderEnums.eventTypes.Message, sprintf('F_CR should be from interval [0,1]; set to default value 0.5\n'));
 end
@@ -186,6 +186,13 @@ FM_meanv = ones(I_NP,I_D);
 
 %
 %FM_pop = zeros(I_NP,2);
+
+if (S_bestval.FVr_oa(1) <= F_VTR)
+   % In this case the while loop should never run so reset 
+   % the random generated best result to default
+   FVr_bestmem = problem.params;
+end
+
 I_iter = 1;
 while ((I_iter < I_itermax) && (S_bestval.FVr_oa(1) > F_VTR))
   FM_popold = FM_pop;                  % save the old population

--- a/minimisers/DREAM/scaledGaussPrior.m
+++ b/minimisers/DREAM/scaledGaussPrior.m
@@ -16,9 +16,9 @@ function pVal2 = scaledGaussPrior(m,extras)
     
     usedPriors = priorList(usedPriorInd,:);
     usedConstr = fitConstr(usedPriorInd,:);
-    usedVals = m(usedPriorInd);
     
     if ~isempty(usedPriorInd)    % There may be no Gaussian priors defined!
+        usedVals = m(usedPriorInd);
         mu = [usedPriors(:,2)];
         sig = [usedPriors(:,3)];
         sigAdd = sig + usedConstr(:,1); % Scale (minVal+prior) will give scaled sigma since minVal goes to 0...


### PR DESCRIPTION
Fixes #271 

The problem was caused by the DE initializing the best results to zeros but the while loop never runs so the result remained zero  

https://github.com/RascalSoftware/RAT/blob/e2067953e504dd81bb0f7f5a7847d9ee419f4850/minimisers/DE/deopt.m#L182-L191

The fix resets the best results to the initial values if the while loop will not be run.