### PR TITLE
Fix exception handling

### DIFF
--- a/API/RATMain.m
+++ b/API/RATMain.m
@@ -36,7 +36,7 @@ if problemStruct.numberOfContrasts > 0
             end
             [problemStruct,result,bayesResults] = runDREAM(problemStruct,problemLimits,controls,priors);
         otherwise
-            error('The procedure "%s" is not supported. The procedure must be one of "%s"', controls.procedure, strjoin(fieldnames(coderEnums.procedures), '", "'));
+            coderException(coderEnums.errorCodes.invalidOption, 'The procedure "%s" is not supported. The procedure must be one of "%s"', controls.procedure, strjoin(fieldnames(coderEnums.procedures), '", "'));
     end
 
     % Then just do a final calculation to fill in SLD if necessary
@@ -48,7 +48,7 @@ if problemStruct.numberOfContrasts > 0
     end
 
 else
-    error("RAT cannot proceed without at least one contrast defined in the project");
+    coderException(coderEnums.errorCodes.domainError, 'RAT cannot proceed without at least one contrast defined in the project');
 end
 
 end

--- a/API/enums/coderEnums.m
+++ b/API/enums/coderEnums.m
@@ -5,6 +5,7 @@ classdef coderEnums
         allowedTypes = allowedTypes.toStruct()
         boundHandlingOptions = boundHandlingOptions.toStruct()
         calculationTypes = calculationTypes.toStruct()
+        errorCodes = errorCodes.toStruct()
         displayOptions = displayOptions.toStruct()
         eventTypes = eventTypes.toStruct()
         geometryOptions = geometryOptions.toStruct()

--- a/API/enums/errorCodes.m
+++ b/API/enums/errorCodes.m
@@ -1,0 +1,21 @@
+classdef errorCodes < customEnum
+   methods (Static)
+        function s = toStruct()
+            s = customEnum.toStruct(mfilename('class'));
+        end
+        
+        function v = values()
+            v = customEnum.values(mfilename('class'));
+        end
+        
+        function e = fromValue(value)
+            e = customEnum.fromValue(mfilename('class'), value);
+        end
+    end
+
+    enumeration
+        unknown (0)
+        invalidOption (1)
+        domainError (2)
+    end
+end

--- a/addPaths.m
+++ b/addPaths.m
@@ -24,6 +24,7 @@ paths = {
     eventCompilePath;
     fullfile(root,'compile');
     fullfile(root,'compile','customWrapper');
+    fullfile(root,'compile','exceptions');
     fullfile(root,'compile','fullCompile');
     fullfile(root,'compile','reflectivityCalculation');
 
@@ -61,7 +62,7 @@ end
 
 addpath(root);
 setappdata(0, 'root', root);
-includedir = {fullfile(root, 'compile', 'customWrapper'), eventCompilePath};
+includedir = {fullfile(root, 'compile', 'customWrapper'), fullfile(root, 'compile', 'exceptions'), eventCompilePath};
 setappdata(0, 'includeDirs', includedir);
 
 % Add the folder with the eventManager dynamic library to the system path so 

--- a/compile/events/eventHelper.hpp
+++ b/compile/events/eventHelper.hpp
@@ -1,5 +1,5 @@
-#ifndef WRAPPER_H
-#define WRAPPER_H
+#ifndef EVENT_HELPER_HPP
+#define EVENT_HELPER_HPP
 
 #include <memory>
 #include <cstdlib>

--- a/compile/exceptions/coderException.hpp
+++ b/compile/exceptions/coderException.hpp
@@ -1,0 +1,19 @@
+#ifndef CODER_EXCEPTION_HPP
+#define CODER_EXCEPTION_HPP
+
+#include <stdexcept>
+
+// Throws the appropriate std exception for the given error code defined 
+// in the errorCodes.m 
+namespace{
+    void coderException(int errorCode, const char* msg)
+    {
+        if (errorCode == 1)
+            throw std::invalid_argument(msg);
+        else if (errorCode == 2)
+            throw std::domain_error(msg);
+        else
+            throw std::exception(msg);
+    }
+}
+#endif // CODER_EXCEPTION_HPP

--- a/compile/exceptions/coderException.m
+++ b/compile/exceptions/coderException.m
@@ -1,0 +1,18 @@
+function coderException(message, varagin)
+    
+    if coder.target('MATLAB') || coder.target('MEX')
+        error(message, varagin);
+    else       
+        coder.cinclude('<stdexcept>');
+        coder.updateBuildInfo('addLinkFlags','-ldl');
+        if isempty(helper)       
+            % Declaration for coder
+            helper = coder.opaque('eventHelper','NULL','HeaderFile','eventHelper.hpp');
+    
+            % Make an instance 
+            helper = coder.ceval('eventHelper');
+            path = [getenv('RAT_PATH'), 0];
+            coder.ceval('std::mem_fn(&eventHelper::init)', helper, path);
+        end
+    end
+end

--- a/compile/exceptions/coderException.m
+++ b/compile/exceptions/coderException.m
@@ -1,18 +1,14 @@
-function coderException(message, varagin)
+function coderException(errorCode, message, varargin)
+    % Ensures a proper exception is thrown in the generated C++ code.
+    % The arguments should be the errorCode integer, error message as a char array (which can be a formatspec) 
+    % and other parameters if message is a formatspec.
+    %
+    % coderException(coderEnums.errorCodes.invalidOption, 'The model type is not supported')
+    % coderException(coderEnums.errorCodes.invalidOption, 'The model type "%s" is not supported', modelType)
     
-    if coder.target('MATLAB') || coder.target('MEX')
-        error(message, varagin);
-    else       
-        coder.cinclude('<stdexcept>');
-        coder.updateBuildInfo('addLinkFlags','-ldl');
-        if isempty(helper)       
-            % Declaration for coder
-            helper = coder.opaque('eventHelper','NULL','HeaderFile','eventHelper.hpp');
-    
-            % Make an instance 
-            helper = coder.ceval('eventHelper');
-            path = [getenv('RAT_PATH'), 0];
-            coder.ceval('std::mem_fn(&eventHelper::init)', helper, path);
-        end
+    if coder.target('C++')     
+        coder.cinclude('coderException.hpp');
+        coder.ceval('coderException', errorCode, sprintf(message, varargin{:}));
     end
+    error(message, varargin{:});
 end

--- a/minimisers/DREAM/functions/checkDREAM.m
+++ b/minimisers/DREAM/functions/checkDREAM.m
@@ -18,7 +18,7 @@ fclose('all');
 if DREAMPar.nChains < (2 * DREAMPar.delta) + 1
     % Error -- not enough chains to do sampling -- increase number of chains!
     stop = true;
-    error('DREAM ERROR: Insufficient number of chains -> Use at least DREAMPar.nChains = %1g chains \n',((2 * DREAMPar.delta) + 1));
+    coderException(coderEnums.errorCodes.domainError, 'DREAM ERROR: Insufficient number of chains -> Use at least DREAMPar.nChains = %1g chains \n',((2 * DREAMPar.delta) + 1));
 end
 
 % Check parameter ranges
@@ -26,7 +26,7 @@ if strcmp(paramInfo,'latin')
     % Error -- if lhs is used -> requires explicit parameter ranges
     if ( sum(isinf(paramInfo.min)) == DREAMPar.nParams )
         stop = true;
-        error('DREAM ERROR: latinHypercubeSampling hypercube sampling selected but parameter ranges not defined -> Set paramInfo.min and paramInfo.max!!\n');
+        coderException(coderEnums.errorCodes.domainError, 'DREAM ERROR: latinHypercubeSampling hypercube sampling selected but parameter ranges not defined -> Set paramInfo.min and paramInfo.max!!\n');
     end
 end
 
@@ -52,9 +52,9 @@ end
 if ( isfield(Meas_info,'Sigma') == 1 ) && ( isfield(Meas_info,'n') == 0 )
     if (prod(size(Meas_info.Sigma)) ~= prod(size(Meas_info.MeasData))) && ( prod(size(Meas_info.Sigma)) > 1 )
         % Error -- Meas_info.Sigma incorrect length!!
-        error('DREAM ERROR: Heteroscedastic error, but length of Meas_info.Sigma is not equal to that of the observations!!\n');
+        coderException(coderEnums.errorCodes.domainError, 'DREAM ERROR: Heteroscedastic error, but length of Meas_info.Sigma is not equal to that of the observations!!');
     elseif ( sum(Meas_info.Sigma<=0) > 0 )
         % Error -- Meas_info.Sigma is negative!!
-        error('DREAM ERROR: At least one value of the specified Meas_info.Sigma is negative or zero!!\n');
+        coderException(coderEnums.errorCodes.domainError, 'DREAM ERROR: At least one value of the specified Meas_info.Sigma is negative or zero!!');
     end
 end

--- a/minimisers/DREAM/functions/multrnd.m
+++ b/minimisers/DREAM/functions/multrnd.m
@@ -5,8 +5,8 @@ function [X,Y] = multrnd(n,p,m)
 %  multinomial distribution with n trials and k outcomes, where the probability for each
 %  simulation is,
 %                          n!    
-%                 ----------------------  ×  p1^n1 × p2^n2 ×  . . .  × pk^nk .  
-%                n1! × n2! ×  . . .  × nk!    
+%                 ----------------------  ï¿½  p1^n1 ï¿½ p2^n2 ï¿½  . . .  ï¿½ pk^nk .  
+%                n1! ï¿½ n2! ï¿½  . . .  ï¿½ nk!    
 %
 %  Then, a single sample {n1, n2,  . . .  , nk} have a multinomial joint distribution with
 %  parameters n and p1, p2,  . . .  , pk. The parameter n is called the number of trials; 
@@ -82,12 +82,12 @@ if nargin < 3
     if nargin == 2
         m = 1;
     else
-        error('You need to input at least two arguments.');
+        coderException(coderEnums.errorCodes.domainError, 'You need to input at least two arguments.');
     end
 end
 
 if (length(n)~=1) | (fix(n) ~= n) | (n < 0)
-   error('n must be a positive integer.');
+    coderException(coderEnums.errorCodes.domainError, 'n must be a positive integer.');
 end
 
 P = sum(p);

--- a/minimisers/DREAM/functions/removeOutlier.m
+++ b/minimisers/DREAM/functions/removeOutlier.m
@@ -206,8 +206,7 @@ else
         triggerEvent(coderEnums.eventTypes.Message, 'DREAMPar.nChains > 60; using Peirce r-values for DREAMPar.nChains is 60');
     end
     if N < 2
-        error('Insufficient number of chains to apply Peirce diagnostic');
-        return;
+        coderException(coderEnums.errorCodes.domainError, 'Insufficient number of chains to apply Peirce diagnostic');
     end
 end
 

--- a/minimisers/NS/nestedSampler.m
+++ b/minimisers/NS/nestedSampler.m
@@ -76,11 +76,11 @@ coder.varsize('nest_samples',[1e5 50],[1 1]);
 
 % check certain values are positive integers or zero
 if mod(nMCMC, 1) ~= 0 || nMCMC < 0
-    error('NS Error: nMCMC must be an integer >= 0')
+    coderException(coderEnums.errorCodes.domainError, 'NS Error: nMCMC must be an integer >= 0')
 end
 
 if mod(nLive, 1) ~= 0 || nLive < 0
-    error('NS Error: nLive must be an integer >= 0')
+    coderException(coderEnums.errorCodes.domainError, 'NS Error: nLive must be an integer >= 0')
 end
 
 % draw the set of initial live points from the prior
@@ -102,7 +102,7 @@ for i=1:D
         p4 = prior(i,3);
         livepoints(:,i) = 10.^(log10(p3) + (log10(p4)-log10(p3))*rand(nLive,1));
     else
-        error('Unrecognised prior for param %d', int32(i));
+        coderException(coderEnums.errorCodes.invalidOption, 'Unrecognised prior for param %d', int32(i));
     end
 end
 

--- a/rmPaths.m
+++ b/rmPaths.m
@@ -10,6 +10,7 @@ paths = {
     fullfile(root,'compile');
     fullfile(root,'compile','customWrapper');
     fullfile(root,'compile','events');
+    fullfile(root,'compile','exceptions');
     fullfile(root,'compile','fullCompile');
     fullfile(root,'compile','reflectivityCalculation');
 

--- a/targetFunctions/common/callReflectivity/applyBackgroundCorrection.m
+++ b/targetFunctions/common/callReflectivity/applyBackgroundCorrection.m
@@ -21,7 +21,7 @@ switch backgroundAction
         shiftedData(:,2) = shiftedData(:,2) - backData;
         shiftedData(:,3) = sqrt(shiftedData(:,3).^2 + backError.^2);   % Propagate the errors
     otherwise
-        error('"%s" does not represent a valid contrast background action.', backgroundAction);
+        coderException(coderEnums.errorCodes.invalidOption, '"%s" does not represent a valid contrast background action.', backgroundAction);
 end
 
 % Reduce data to original three columns

--- a/targetFunctions/common/callReflectivity/callReflectivity.m
+++ b/targetFunctions/common/callReflectivity/callReflectivity.m
@@ -99,7 +99,7 @@ switch refType
                 end
         end
     otherwise
-        error('The reflectivity type "%s" is not supported', refType);
+        coderException(coderEnums.errorCodes.invalidOption, 'The reflectivity type "%s" is not supported', refType);
 end
 
 simulation(:,2) = simRef(:);

--- a/targetFunctions/common/constructBackground.m
+++ b/targetFunctions/common/constructBackground.m
@@ -43,7 +43,7 @@ if strcmpi(backgroundType, coderEnums.allowedTypes.Function)
             thisBackground = feval(funcName, background(:,1), paramsArray);
         end
     else
-        error('Background functions in languages other than MATLAB are not supported.');
+        coderException(coderEnums.errorCodes.invalidOption, 'Background functions in languages other than MATLAB are not supported.');
     end
 
     background(:,2) = background(:,2) + thisBackground;

--- a/targetFunctions/common/customModelFunctions/callCppFunction.m
+++ b/targetFunctions/common/customModelFunctions/callCppFunction.m
@@ -41,7 +41,7 @@ function [output,subRough] = callCppFunction(pointer, params, bulkIn, bulkOut, c
     actualSize = coder.ceval('convertVector2Ptr', outArray, coder.wref(tempOutput));
 
     if size ~= actualSize
-        error('The output of the custom function with size %d does not match the specified size (%d x %d).', actualSize, outputSize(2), outputSize(1))
+        coderException(coderEnums.errorCodes.domainError, 'The output of the custom function with size %.0f does not match the specified size (%.0f x %.0f).', actualSize, outputSize(2), outputSize(1));
     end
     output = reshape(tempOutput, [outputSize(2), outputSize(1)])';
 end

--- a/targetFunctions/common/customModelFunctions/callMatlabFunction.m
+++ b/targetFunctions/common/customModelFunctions/callMatlabFunction.m
@@ -20,5 +20,5 @@ else
     % Calling matlab from other languages should be implemented in their wrapper
     sRough = 0;
     output = zeros([0 0]);
-    error("This is not supported!");
+    coderException(coderEnums.errorCodes.unknown, 'This is not supported!');
 end

--- a/targetFunctions/reflectivityCalculation.m
+++ b/targetFunctions/reflectivityCalculation.m
@@ -48,7 +48,7 @@ switch targetFunction
                  subRoughs] = normalTF.customXY(problemStruct,controls);
 
             otherwise
-                error('The model type "%s" is not supported', modelType);
+                coderException(coderEnums.errorCodes.invalidOption, 'The model type "%s" is not supported', modelType);
         end
 
     %case coderEnums.calculationTypes.OilWater
@@ -82,11 +82,11 @@ switch targetFunction
                  subRoughs] = domainsTF.customXY(problemStruct,controls);
 
             otherwise
-                error('The model type "%s" is not supported', modelType);
+                coderException(coderEnums.errorCodes.invalidOption, 'The model type "%s" is not supported', modelType);
         end
 
     otherwise
-        error('The calculation type "%s" is not supported', targetFunction);
+        coderException(coderEnums.errorCodes.invalidOption, 'The calculation type "%s" is not supported', targetFunction);
 end
 
 % Make the result struct


### PR DESCRIPTION
Fixes #297 

I replaced all instances of `error(...)` in the complied code, I did not replace `error(...) `in 3rdParty or Dream diagnostics.
I also tested on python-RAT, passing in an invalid TF for example should now raise a ValueError instead of failing silently
