### PR TITLE
Fixes exception build issue

### DIFF
--- a/compile/exceptions/coderException.hpp
+++ b/compile/exceptions/coderException.hpp
@@ -13,7 +13,7 @@ namespace{
         else if (errorCode == 2)
             throw std::domain_error(msg);
         else
-            throw std::exception(msg);
+            throw std::runtime_error(msg);
     }
 }
 #endif // CODER_EXCEPTION_HPP


### PR DESCRIPTION
This should fix 

> error: no matching function for call to ‘std::exception::exception(const char*&)’