### PR TITLE
replaces `randsample` with a custom-built `randSample` function

### DIFF
--- a/minimisers/DREAM/functions/randSample.m
+++ b/minimisers/DREAM/functions/randSample.m
@@ -1,0 +1,57 @@
+function outputSample = randSample(population, numItems, weights)
+  % Take a random sample of values.
+  % 
+  % Parameters
+  % ----------
+  % population : vector or int
+  %   if a vector, sample k values from the vector without replacement.
+  %   if an int, sample k values from 1:n without replacement.
+  % numItems : int
+  %   the number of items to sample.
+  % weights : vector
+  %   a weight vector, where the i'th index of ``weights`` is the 
+  %   weight for the i'th member of the population.
+
+  % if the user is trying to get multiple items from a single-integer array,
+  % assume that they want to sample between 1 and n
+  if isscalar(population) && numItems > 1
+    population = 1:population;
+  end
+
+  switch nargin
+    case 1
+      numItems = 1;
+      weights = 1;
+    case 2
+      weights = ones(1, length(population));
+    case 3
+      % do nothing
+    otherwise
+      error("Too many arguments.")
+  end
+
+  if numItems > length(population)
+    error("numItems is larger than the number of items in the population.")
+  end
+  if length(weights) ~= length(population)
+    error("Weights and population must be the same length.")
+  end
+
+  % create vector for results
+  outputSample = zeros(1, numItems);
+
+  for i = 1:numItems
+    % we generate weighted random integers by creating bins from our weights
+    % and discretizing a random number in [0, 1] to those bins
+    weights = normalize(weights, 'norm', 1);
+    bins = [0, cumsum(weights)];
+    bins(end) = 1;  % ensure final bin is 1 as normalize is not always exact
+
+    randomIndex = discretize(rand(1), bins);
+
+    outputSample(i) = population(randomIndex);
+    population(randomIndex) = [];
+    weights(randomIndex) = [];
+  end
+end
+

--- a/minimisers/DREAM/functions/randSample.m
+++ b/minimisers/DREAM/functions/randSample.m
@@ -18,40 +18,55 @@ function outputSample = randSample(population, numItems, weights)
     population = 1:population;
   end
 
-  switch nargin
-    case 1
-      numItems = 1;
-      weights = 1;
-    case 2
-      weights = ones(1, length(population));
-    case 3
-      % do nothing
-    otherwise
-      error("Too many arguments.")
+  nargs = nargin;
+
+  if nargs > 3
+    error("Too many arguments.")
   end
 
   if numItems > length(population)
     error("numItems is larger than the number of items in the population.")
   end
-  if length(weights) ~= length(population)
-    error("Weights and population must be the same length.")
-  end
 
   % create vector for results
   outputSample = zeros(1, numItems);
 
-  for i = 1:numItems
-    % we generate weighted random integers by creating bins from our weights
-    % and discretizing a random number in [0, 1] to those bins
-    weights = normalize(weights, 'norm', 1);
-    bins = [0, cumsum(weights)];
-    bins(end) = 1;  % ensure final bin is 1 as normalize is not always exact
+  if nargs == 3
 
-    randomIndex = discretize(rand(1), bins);
+    if length(weights) ~= length(population)
+      error("Weights and population must be the same length.")
+    end
 
-    outputSample(i) = population(randomIndex);
-    population(randomIndex) = [];
-    weights(randomIndex) = [];
+    for i = 1:numItems
+      % we generate weighted random integers by creating bins from our weights
+      % and discretizing a random number in [0, 1] to those bins
+      weights = normalize(weights, 'norm', 1);
+      bins = [0, cumsum(weights)];
+      bins(end) = 1;  % ensure final bin is 1 as normalize is not always exact
+
+      randomIndex = discretize(rand(1), bins);
+
+      outputSample(i) = population(randomIndex);
+      population(randomIndex) = [];
+      weights(randomIndex) = [];
+    end
+
+  % we can generate unweighted numbers far more efficiently
+  else
+    % for large numbers of items it's more efficient to randomise the array
+    % and return the first numItems items
+    if 4*numItems > length(population)
+      population = population(randperm(length(population)));
+      outputSample = population(1:numItems);
+    % else, just generate random integers and pick items from the population
+    else
+      for i = 1:numItems
+        randomIndex = randi(length(population));
+        outputSample(i) = population(randomIndex);
+        population(randomIndex) = [];
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
This PR fixes part of #146 by replacing `randsample` from the Statistical Toolbox with a home-made implementation.

Note that of the [six potential operations of `randsample`](https://www.mathworks.com/help/stats/randsample.html), this only implements four:
- `randsample(n, k)` $\rightarrow$ `randSample(n, k)` (sample `k` random integers between 1 and `n` without replacement)
- `randsample(population, k)` $\rightarrow$ `randSample(population, k)` (sample `k` random items from `population` without replacement
- `randsample(n, k, true, w)` $\rightarrow$ `randSample(n, k, w)` (sample `k` random integers between 1 and `n` without replacement, with weights `w`)
- `randsample(population, k, true, w)` $\rightarrow$ `randSample(population, k, w)` (sample `k` random items from `population` without replacement, with weights `w`)

It doesn't seem like RAT uses `randsample(___, replacement)` or `randsample(s, ___)`. I also removed the extraneous argument `true` from the weighted options (I'm not sure what it's for!)

