### PR TITLE
Removed debug print statements from nested sampler and added errors where necessary

### DIFF
--- a/compile/fullCompile/ratMainCodeGen.m
+++ b/compile/fullCompile/ratMainCodeGen.m
@@ -27,4 +27,4 @@ includes = cell(length(includeDirs)*2, 1);
 includes(1:2:end) = {'-I'};
 includes(2:2:end) = includeDirs;
 
-codegen('RATMain', '-globals', '{"DEBUG", 0}', '-config', cfg, '-args',  ARGS{1}, includes{:});
+codegen('RATMain', '-config', cfg, '-args',  ARGS{1}, includes{:});

--- a/compile/fullCompile/ratMainMexBuild.m
+++ b/compile/fullCompile/ratMainMexBuild.m
@@ -17,4 +17,4 @@ includeDirs = getappdata(0,'includeDirs');
 includes = cell(length(includeDirs)*2, 1);
 includes(1:2:end) = {'-I'};
 includes(2:2:end) = includeDirs;
-codegen('RATMain', '-globals', '{"DEBUG", 0}', '-config', cfg, '-args',  ARGS{1}, includes{:});
+codegen('RATMain', '-config', cfg, '-args',  ARGS{1}, includes{:});

--- a/minimisers/NS/calcEllipsoid.m
+++ b/minimisers/NS/calcEllipsoid.m
@@ -16,8 +16,6 @@ function [B, mu, VE, flag] = calcEllipsoid(u, VS)
 %          has bad condition number; otherwise = 0
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-global DEBUG
-
 % default values
 B = [];
 mu = [];
@@ -30,9 +28,7 @@ ndims = size(u, 2);
 
 % check that total number of points is large enough
 if N < ndims+1
-    if DEBUG; fprintf('number of samples too small to calculate bounding matrix for ellipsoid\n'); end;
-    flag = 1;
-    return;
+    coderException(coderEnums.errorCodes.domainError, 'The number of live points must be larger than the number of fit parameters for MultiNest.'); 
 end
 
 % constant factor for volume of ellipsoid
@@ -43,10 +39,8 @@ C = cov(u);
 mu = mean(u);
 
 % check condition number of C (eps = 2.2204e-16)
-if rcond(C)<eps || isnan(rcond(C)) 
-    if DEBUG; fprintf('bad condition number!\n'); end
-    flag = 1;
-    return;
+if rcond(C)<eps || isnan(rcond(C))
+    coderException(coderEnums.errorCodes.domainError, 'Bad condition number for covariance matrix of ellipsoid.'); 
 end
 
 % find scale factor for bounding ellipsoid E

--- a/minimisers/NS/drawMultiNest.m
+++ b/minimisers/NS/drawMultiNest.m
@@ -9,8 +9,6 @@ function [sample, logL] = drawMultiNest(fracvol, Bs, mus, ...
     % extraparvals is a vector of additional parameters needed by the model.
     %
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    global DEBUG
-    
     % extra number of ellipsoids, number of dimensions 
     K = size(mus, 1);
     ndims = size(mus,2);
@@ -51,7 +49,6 @@ function [sample, logL] = drawMultiNest(fracvol, Bs, mus, ...
             for ii=1:ndims
                  if pnt(ii)<0 || pnt(ii)>1
                      in_range = 0;
-                     if DEBUG; fprintf('new point not in range!!!!\n'); end
                  end
             end
                 

--- a/minimisers/NS/nestedSampler.m
+++ b/minimisers/NS/nestedSampler.m
@@ -46,14 +46,9 @@ function [logZ, nest_samples, post_samples,H] = nestedSampler(data, ...
 %                      'x', 4};
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% global verbose;
-global DEBUG;
-
 extraparvals = [];
 
 controls = data{2};
-% verbose = 1;
-DEBUG = 0;
 
 % get the number of parameters from the prior array
 D = size(prior,1);

--- a/minimisers/NS/optimalEllipsoids.m
+++ b/minimisers/NS/optimalEllipsoids.m
@@ -17,8 +17,6 @@ function [Bs, mus, VEs, ns] = optimalEllipsoids(u, VS)
 %   ns:  an array containing the number of points for each subcluster (K x 1)
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-global DEBUG
-
 N = size(u,1); % number of samples in multi-dimensional space
 ndims = size(u,2); % number of dimensions
 K = 1;
@@ -50,9 +48,6 @@ else
     test1 = all(VE1 + VE2 < VE); 
     test2 = all(VE > 2*VS);
     if  all(test1) || all(test2) 
-        if DEBUG
-            fprintf('PARTITION ACCEPTED: N=%d splits to n1=%d, n2=%d\n', int32(N), int32(n1), int32(n2));
-        end
         K = K + 1;
         VS1 = n1 * VS / N;
         VS2 = n2 * VS / N;
@@ -65,9 +60,6 @@ else
         VEs = [VE1 ; VE2];
         ns =  [n1 ; n2];
     else
-        if DEBUG
-            fprintf('PARTITION REJECTED: N=%d doesnt split into n1=%d and n2=%d\n', int32(N), int32(n1), int32(n2));
-        end
         Bs = B;
         mus = mu;
         VEs = VE;

--- a/minimisers/NS/splitEllipsoid.m
+++ b/minimisers/NS/splitEllipsoid.m
@@ -14,7 +14,6 @@ function [u1, u2, VE1, VE2, nosplit] = splitEllipsoid(u, VS)
 % is set to 1 if the splitting cannot be done; otherwise = 0.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-global DEBUG
 max_attempt = 50; % maximum number of attempts to recluster points
 
 % default return values
@@ -30,7 +29,6 @@ D = size(u,2);
 
 % check total number of samples
 if N < 2*(D+1)
-    if DEBUG; fprintf('CANT SPLIT: total number of samples is too small!  N = %d\n', int32(N)); end;
     nosplit = 1;
     return;
 end
@@ -45,7 +43,6 @@ n2 = size(u2,1); % number of samples in S2
 
 % check number of points in subclusters
 if n1 < D+1 || n2 < D+1
-    if DEBUG; fprintf('CANT SPLIT: number of samples in subclusters is too small! n1 = %d, n2 = %d\n', int32(n1), int32(n2)); end;
     nosplit = 1;
     return;
 end
@@ -72,7 +69,6 @@ while 1
     
     % check flags
     if flag1 || flag2
-        if DEBUG; fprintf('CANT SPLIT!!\n'); end
         nosplit = 1;
         break
     end
@@ -84,12 +80,6 @@ while 1
     temp_VE1(counter) = VE1;
     temp_VE2(counter) = VE2;
     FS(counter)=(VE1+VE2)/VS;
-
-    % DEBUG print statement
-%     if DEBUG
-%         fprintf('SPLIT ELLIPSOID: counter = %d, numreassigned = %d\n', ...
-%                 int32(counter), int32(numreassigned));
-%     end
 
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     % check if points need to be reassigned to the other subcluster
@@ -152,14 +142,6 @@ while 1
     if reassign && counter <= max_attempt
         continue
     else
-        % DEBUG print statement
-%         if DEBUG 
-%             %fprintf('SPLIT ELLIPSOID: counter = %d, FS = %f, numreassigned = %d\n', counter, (VE1+VE2)/VS, numreassigned);
-%             if counter > max_attempt
-%                 fprintf('SPLIT ELLIPSOID: exceeded maximum attempts; take min F(S).\n');
-%             end
-%         end
-
         break
     end
 
@@ -171,7 +153,5 @@ u1 = temp_u1{idx};
 u2 = temp_u2{idx};
 VE1 = temp_VE1(idx);
 VE2 = temp_VE2(idx);
-
-if DEBUG; fprintf('SPLIT ELLIPSOID: min F(S) = %f\n', minFS); end
 
 end


### PR DESCRIPTION
a global DEBUG variable was used by the nested sampler to produce debug output. Most of this output was just information, however in calcEllipsoids, the debug print was the only information given to the user before a bad output was allowed to just cascade and create an unintuitive error elsewhere. This PR removes the global DEBUG flag from NS and makes the algorithm create errors where necessary instead. Fixes #345