### PR TITLE
Adds docstrings to enums

### DIFF
--- a/API/enums/actions.m
+++ b/API/enums/actions.m
@@ -1,4 +1,5 @@
 classdef actions < customEnum
+  % Ways in which a background can be included in a contrast.
     methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/allowedTypes.m
+++ b/API/enums/allowedTypes.m
@@ -1,4 +1,5 @@
 classdef allowedTypes < customEnum
+  % Ways of defining a background or resolution.
     methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/boundHandlingOptions.m
+++ b/API/enums/boundHandlingOptions.m
@@ -1,4 +1,5 @@
 classdef boundHandlingOptions < customEnum
+  % Options for bound handling in DREAM.
     methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/calculationTypes.m
+++ b/API/enums/calculationTypes.m
@@ -1,4 +1,5 @@
 classdef calculationTypes < customEnum
+  % Types of calculation that can be performed by RAT.
    methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/coderEnums.m
+++ b/API/enums/coderEnums.m
@@ -1,5 +1,5 @@
-% This allow enums to be used by coder without redefinition or hardcoding
 classdef coderEnums
+  % An Enum class which lets MATLAB Coder use Enums without redefinition or hardcoding.
     properties (Constant)
         actions = actions.toStruct()
         allowedTypes = allowedTypes.toStruct()

--- a/API/enums/displayOptions.m
+++ b/API/enums/displayOptions.m
@@ -1,4 +1,5 @@
 classdef displayOptions < customEnum 
+  % The available options for terminal output.
     methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/errorCodes.m
+++ b/API/enums/errorCodes.m
@@ -1,4 +1,5 @@
 classdef errorCodes < customEnum
+  % Internal error codes for MATLAB Coder exceptions (see compile/exceptions/coderException.m).
    methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/eventTypes.m
+++ b/API/enums/eventTypes.m
@@ -1,4 +1,5 @@
 classdef eventTypes < customEnum
+  % Types of output event from a RAT run.
    methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/geometryOptions.m
+++ b/API/enums/geometryOptions.m
@@ -1,4 +1,8 @@
 classdef geometryOptions < customEnum
+  % Where the substrate roughness is placed.
+  %
+  % For air/substrate, it is placed at the end of the stack.
+  % For substrate/liquid, it is placed at the beginning of the stack.
    methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/hydrationTypes.m
+++ b/API/enums/hydrationTypes.m
@@ -1,4 +1,5 @@
 classdef hydrationTypes < customEnum
+  % Options for the 'hydrate with' parameter of a Layer.
     methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/modelTypes.m
+++ b/API/enums/modelTypes.m
@@ -1,4 +1,5 @@
 classdef modelTypes < customEnum
+  % Types of layer model supported by RAT.
     methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/parallelOptions.m
+++ b/API/enums/parallelOptions.m
@@ -1,4 +1,5 @@
 classdef parallelOptions < customEnum
+  % Ways in which the calculation can be parallelised.
     methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/priorTypes.m
+++ b/API/enums/priorTypes.m
@@ -1,4 +1,5 @@
 classdef priorTypes < customEnum
+  % Prior distributions for parameters in Bayesian algorithms.
    methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/procedures.m
+++ b/API/enums/procedures.m
@@ -1,4 +1,5 @@
 classdef procedures < customEnum
+  % The algorithms available in RAT.
    methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));

--- a/API/enums/searchStrategy.m
+++ b/API/enums/searchStrategy.m
@@ -1,4 +1,5 @@
 classdef searchStrategy < customEnum
+  % Strategies for generating base vectors in differential evolution.
    methods (Static)           
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'), true);

--- a/API/enums/supportedLanguages.m
+++ b/API/enums/supportedLanguages.m
@@ -1,4 +1,5 @@
 classdef supportedLanguages < customEnum
+  % Languages for custom files.
    methods (Static)
         function s = toStruct()
             s = customEnum.toStruct(mfilename('class'));


### PR DESCRIPTION
This PR adds docstrings for the enum classes in API/enums.

These docstrings are just taken from the equivalent enums in RAT, with extra explanatory comments where relevant.