### PR TITLE
Adds workaround for ARM macs

### DIFF
--- a/compile/customWrapper/classHandle.hpp
+++ b/compile/customWrapper/classHandle.hpp
@@ -60,9 +60,9 @@ template<class base> inline std::string convertPtr2String(base *ptr)
     return std::to_string(handle);
 }
 
-template<class base> inline ClassHandle<base> *convertString2HandlePtr(const char* in)
+template<class base> inline ClassHandle<base> *convertString2HandlePtr(const char* in, int size)
 {
-    uint64_t value = stoull(std::string(in));
+    uint64_t value = stoull(std::string(in).substr(0, size));
     ClassHandle<base> *ptr = reinterpret_cast<ClassHandle<base> *>(value);
     if (!ptr->isValid())
        throw std::invalid_argument("callback handle is not valid");

--- a/compile/customWrapper/wrapperMex.cpp
+++ b/compile/customWrapper/wrapperMex.cpp
@@ -52,7 +52,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (nrhs != 2)
 		    mexErrMsgTxt("Second input for delete command should be a class instance handle.");
         size_t size = mxGetNumberOfElements(prhs[1]);
-        destroyObject<CallbackInterface>(getStringFromMxArray(prhs[1], "class instance handle should a row vector char array"), size);
+        destroyObject<CallbackInterface>(getStringFromMxArray(prhs[1], "class instance handle should be a row vector char array"), size);
         if (nlhs != 0 || nrhs != 2)
             mexWarnMsgTxt("Delete: Unexpected arguments ignored.");
         return;

--- a/compile/customWrapper/wrapperMex.cpp
+++ b/compile/customWrapper/wrapperMex.cpp
@@ -9,9 +9,9 @@ template<class base> inline mxArray *convertPtr2Mat(base *ptr)
     return mxCreateString(convertPtr2String<base>(ptr).c_str());
 }
 
-template<class base> inline void destroyObject(const char* in)
+template<class base> inline void destroyObject(const char* in, size_t size)
 {
-    delete convertString2HandlePtr<base>(in);
+    delete convertString2HandlePtr<base>(in, size);
     mexUnlock();
 }
 
@@ -51,7 +51,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     if (!strcmp("delete", cmd)) {    
         if (nrhs != 2)
 		    mexErrMsgTxt("Second input for delete command should be a class instance handle.");
-        destroyObject<CallbackInterface>(getStringFromMxArray(prhs[1], "class instance handle should a row vector char array"));
+        size_t size = mxGetNumberOfElements(prhs[1]);
+        destroyObject<CallbackInterface>(getStringFromMxArray(prhs[1], "class instance handle should a row vector char array"), size);
         if (nlhs != 0 || nrhs != 2)
             mexWarnMsgTxt("Delete: Unexpected arguments ignored.");
         return;

--- a/targetFunctions/common/customModelFunctions/callCppFunction.m
+++ b/targetFunctions/common/customModelFunctions/callCppFunction.m
@@ -8,7 +8,7 @@ function [output, varargout] = callCppFunction(pointer, varargin)
     coder.cinclude('classHandle.hpp')
     
     callbackHandle = coder.opaque('ClassHandle<CallbackInterface> *','NULL');
-    callbackHandle = coder.ceval('convertString2HandlePtr<CallbackInterface>', pointer);
+    callbackHandle = coder.ceval('convertString2HandlePtr<CallbackInterface>', pointer, numel(pointer));
 
     callback = coder.opaque('CallbackInterface *','NULL');
     callback = coder.ceval('std::mem_fn(&ClassHandle<CallbackInterface>::ptr)', callbackHandle);


### PR DESCRIPTION
The is a workaround for the crash when using `ratapi` on ARM macs