### PR TITLE
Adds the shiftValue argument to plotRefSLD

### DIFF
--- a/utilities/plotting/plotRefSLD.m
+++ b/utilities/plotting/plotRefSLD.m
@@ -18,7 +18,7 @@ function plotRefSLD(project, result, options)
     %       * showErrorBar (logical, default: true) indicates if the error bar should be shown.
     %       * showGrid (logical, default: false) indicates if the grid should be shown.
     %       * showLegend (logical, default: true) indicates if the legend should be shown.
-    %       * shiftValue (float, default: 100) A value between 1 and 100 that controls the spacing between the reflectivity plots for each contrasts.   
+    %       * shiftValue (float, default: 100) A value between 1 and 100 that controls the spacing between the reflectivity plots for each of the contrasts.   
     
     arguments
         project

--- a/utilities/plotting/plotRefSLD.m
+++ b/utilities/plotting/plotRefSLD.m
@@ -17,7 +17,8 @@ function plotRefSLD(project, result, options)
     %       * q4 (logical, default: false) indicates if the Y axis should plot Q^4.
     %       * showErrorBar (logical, default: true) indicates if the error bar should be shown.
     %       * showGrid (logical, default: false) indicates if the grid should be shown.
-    %       * showLegend (logical, default: true) indicates if the legend should be shown. 
+    %       * showLegend (logical, default: true) indicates if the legend should be shown.
+    %       * shiftValue (float, default: 100) A value between 1 and 100 that controls the spacing between the reflectivity plots for each contrasts.   
     
     arguments
         project
@@ -27,6 +28,7 @@ function plotRefSLD(project, result, options)
         options.showErrorBar {mustBeA(options.showErrorBar, 'logical')} = true
         options.showGrid {mustBeA(options.showGrid, 'logical')} = false
         options.showLegend {mustBeA(options.showLegend, 'logical')} = true
+        options.shiftValue {mustBeGreaterThanOrEqual(options.shiftValue, 1), mustBeLessThanOrEqual(options.shiftValue, 100)} = 100
     end
     % Convert the project class to a struct.
     controls = controlsClass();
@@ -43,5 +45,5 @@ function plotRefSLD(project, result, options)
     data.contrastNames = projectStruct.names.contrasts;
     
     plotRefSLDHelper(data, false, options.linearX, options.q4, options.showErrorBar, ...
-                     options.showGrid, options.showLegend);
+                     options.showGrid, options.showLegend, options.shiftValue);
 end

--- a/utilities/plotting/plotRefSLDHelper.m
+++ b/utilities/plotting/plotRefSLDHelper.m
@@ -1,4 +1,4 @@
-function plotRefSLDHelper(data, noDelay, linearX, q4, showErrorBar, showGrid, showLegend)
+function plotRefSLDHelper(data, noDelay, linearX, q4, showErrorBar, showGrid, showLegend, shiftValue)
     % Helper function to plot the reflectivity and SLD profiles from plot event struct. 
     % Most users never need to use this function, rather use ``useLivePlot`` for live 
     % plotting or ``plotRefSLD`` for simple SLD plots. 
@@ -39,7 +39,9 @@ function plotRefSLDHelper(data, noDelay, linearX, q4, showErrorBar, showGrid, sh
     % showGrid : logical, default: false
     %    Indicates if the grid should be shown.
     % showLegend : logical, default: true
-    %    Indicates if the legend should be shown.    
+    %    Indicates if the legend should be shown.
+    % shiftValue : float, default: 100
+    %    A value between 1 and 100 that controls the spacing between the reflectivity plots for each contrasts.     
 
     arguments
         data
@@ -49,8 +51,8 @@ function plotRefSLDHelper(data, noDelay, linearX, q4, showErrorBar, showGrid, sh
         showErrorBar {mustBeA(showErrorBar, 'logical')} = true
         showGrid {mustBeA(showGrid, 'logical')} = false
         showLegend {mustBeA(showLegend, 'logical')} = true
-    end
-
+        shiftValue {mustBeGreaterThanOrEqual(shiftValue, 1), mustBeLessThanOrEqual(shiftValue, 100)} = 100
+    end 
     defaultState = 'on';
     s = warning();
     if any(strcmp({s.identifier}, 'MATLAB:Axes:NegativeDataInLogAxis'))
@@ -81,7 +83,7 @@ function plotRefSLDHelper(data, noDelay, linearX, q4, showErrorBar, showGrid, sh
         thisRef = data.reflectivity{i};
         thisData = data.shiftedData{i};
         if i > 1 || q4
-            mult = 2^(4*i);
+            mult = 10.^((i/100)*shiftValue);
         end
         
         if q4 && data.dataPresent(i)

--- a/utilities/plotting/plotRefSLDHelper.m
+++ b/utilities/plotting/plotRefSLDHelper.m
@@ -41,7 +41,7 @@ function plotRefSLDHelper(data, noDelay, linearX, q4, showErrorBar, showGrid, sh
     % showLegend : logical, default: true
     %    Indicates if the legend should be shown.
     % shiftValue : float, default: 100
-    %    A value between 1 and 100 that controls the spacing between the reflectivity plots for each contrasts.     
+    %    A value between 1 and 100 that controls the spacing between the reflectivity plots for each of the contrasts.     
 
     arguments
         data


### PR DESCRIPTION
`shiftValue` adjusts the spacing between the reflectivity plots in `plotRefSLD` 