### PR TITLE
Fixes empty layers bug

### DIFF
--- a/targetFunctions/common/groupLayers/groupLayersMod.m
+++ b/targetFunctions/common/groupLayers/groupLayersMod.m
@@ -40,7 +40,7 @@ if ~isempty(layers)
 
 else
 
-    outputLayers = zeros(1, 4);
+    outputLayers = zeros(0, 4);
     
 end
 


### PR DESCRIPTION
Fixes #419 

This PR fixes the bug that occurs where a contract containing no layers is viewed as a single layer of zero thickness. This was introduced in the routine `groupLayersMod`, where it was necessary to ensure `outputLayers` was defined on all branches of the if statement. By replacing the line of zeros with an appropriately sized empty array, we retain all code functionality, ensuring the following routines, `applyHydration` and `makeSLDProfile`, behave as expected when there are no layers. I have also confirmed that the plot looks as we expect with this change.

@arwelHughes this PR means there is no need to add the check to `makeSLDProfile` that we discussed this morning.